### PR TITLE
fix: support code annotations for unknown languages and idiomatic highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: default to `#` comment symbol for unknown code block languages (`default`, `txt`, etc.) in annotation detection.
+- fix: support code annotations with `syntax-highlighting: idiomatic` (native Typst highlighting) via a `show raw.line` rule.
+
 ## 0.3.0 (2026-03-23)
 
 ### New Features

--- a/_extensions/code-window/_modules/hotfix/code-annotations.lua
+++ b/_extensions/code-window/_modules/hotfix/code-annotations.lua
@@ -101,10 +101,7 @@ local function resolve_annotations(block)
   end
 
   local lang = block.classes[1]:lower()
-  local comment = LANG_COMMENT_CHARS[lang]
-  if not comment then
-    return block.text, nil
-  end
+  local comment = LANG_COMMENT_CHARS[lang] or '#'
 
   local escaped_comment = escape_pattern(comment)
   local pattern = '^(.-)%s*' .. escaped_comment .. '%s*<%s*(%d+)%s*>%s*$'

--- a/_extensions/code-window/_modules/hotfix/skylighting-typst-fix.lua
+++ b/_extensions/code-window/_modules/hotfix/skylighting-typst-fix.lua
@@ -102,6 +102,56 @@ local function build_skylighting_override()
 ]==], bg, circled, circled)
 end
 
+--- Build a show raw.line rule for annotation support in idiomatic mode.
+--- When Skylighting is not available (idiomatic/native Typst highlighting),
+--- this rule reads _cw-annotations state and adds circled annotation markers
+--- to annotated lines, mirroring what the Skylighting override does.
+--- @return string Typst show rule definition
+local function build_raw_line_annotation_rule()
+  local circled = _wrapper_prefix .. '-circled-number'
+  return string.format([==[
+// idiomatic-mode annotation support for raw blocks
+#show raw.line: it => {
+  context {
+    let annot-data = _cw-annotations.get()
+    if annot-data == none {
+      it
+    } else {
+      let annot-num = annot-data.annotations.at(str(it.number), default: none)
+      if annot-num == none {
+        it
+      } else {
+        let lbl-prefix = "cw-" + str(annot-data.block-id) + "-"
+        let first-line = calc.min(
+          ..annot-data.annotations.pairs()
+            .filter(p => p.at(1) == annot-num)
+            .map(p => int(p.at(0)))
+        )
+        if it.number == first-line {
+          box(width: 100%%)[
+            #it
+            #h(1fr)
+            #link(label(lbl-prefix + "item-" + str(annot-num)))[
+              #%s(annot-num, bg-colour: annot-data.bg-colour)
+            ]
+            #label(lbl-prefix + "line-" + str(annot-num))
+          ]
+        } else {
+          box(width: 100%%)[
+            #it
+            #h(1fr)
+            #link(label(lbl-prefix + "item-" + str(annot-num)))[
+              #%s(annot-num, bg-colour: annot-data.bg-colour)
+            ]
+          ]
+        }
+      }
+    }
+  }
+}
+]==], circled, circled)
+end
+
 --- Process inline Code for Typst format.
 --- Renders the Code element through Pandoc's Typst writer to get syntax-
 --- highlighted output, then wraps it in a box with the theme background colour.
@@ -142,20 +192,19 @@ function Pandoc(doc)
     return doc
   end
 
-  -- Guard: skip if override already injected.
+  -- Guard: skip if override or annotation rule already injected.
   for _, blk in ipairs(doc.blocks) do
     if blk.t == 'RawBlock' and blk.format == 'typst'
-        and blk.text:find('// skylighting-typst-fix override', 1, true) then
+        and (blk.text:find('// skylighting-typst-fix override', 1, true)
+          or blk.text:find('// idiomatic-mode annotation support', 1, true)) then
       return doc
     end
   end
 
   local override = build_skylighting_override()
-  if not override then
-    return doc
-  end
+  local rule = override or build_raw_line_annotation_rule()
 
-  -- Insert after the code-window function definitions so Skylighting can
+  -- Insert after the code-window function definitions so the override/rule can
   -- reference _cw-annotations and the wrapper-prefixed circled-number function.
   local insert_pos = 1
   for idx, blk in ipairs(doc.blocks) do
@@ -165,7 +214,7 @@ function Pandoc(doc)
       break
     end
   end
-  table.insert(doc.blocks, insert_pos, pandoc.RawBlock('typst', override))
+  table.insert(doc.blocks, insert_pos, pandoc.RawBlock('typst', rule))
   return doc
 end
 

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -138,13 +138,19 @@ local TYPST_ANNOTATION_DEF = [==[
 
 #let code-window-annotation-item(block-id, n, content) = {
   let lbl-prefix = "cw-" + str(block-id) + "-"
-  [#block(above: 0.4em, below: 0.4em)[
-    #link(label(lbl-prefix + "line-" + str(n)))[
-      #code-window-circled-number(n)
-    ]
-    #h(0.4em)
-    #content
-  ] #label(lbl-prefix + "item-" + str(n))]
+  context {
+    let target = label(lbl-prefix + "line-" + str(n))
+    let has-target = query(target).len() > 0
+    [#block(above: 0.4em, below: 0.4em)[
+      #if has-target {
+        link(target)[#code-window-circled-number(n)]
+      } else {
+        code-window-circled-number(n)
+      }
+      #h(0.4em)
+      #content
+    ] #label(lbl-prefix + "item-" + str(n))]
+  }
 }
 
 #let code-window-annotated-content(content, annotations: (:), bg-colour: none, block-id: 0) = {


### PR DESCRIPTION
Default to `#` as comment symbol for unmapped code block languages (`default`, `txt`, etc.) in annotation detection, matching Quarto's own behaviour.

Add a `show raw.line` Typst rule for `syntax-highlighting: idiomatic` mode where the Skylighting override is absent, placing circled annotation markers on annotated lines with bidirectional linking.

Make `code-window-annotation-item` resilient to missing line labels by querying for the target label before creating a link.