### PR TITLE
docs: document all extension options and block-level attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,15 @@ Each hotfix value can be a simple boolean or a map with `enabled` and `quarto-ve
 - **`"windows"`**: Minimise, maximise, and close buttons on the right, filename on the left.
 - **`"default"`**: Plain filename on the left, no window decorations.
 
-### Block-Level Style Override
+### Block-Level Attributes
 
-Override the style for a single code block using the `code-window-style` attribute:
+Override the style or disable features for a single code block:
+
+| Attribute                       | Type    | Default | Description                                                            |
+| ------------------------------- | ------- | ------- | ---------------------------------------------------------------------- |
+| `code-window-style`             | string  |         | Override the global style for this block: `"macos"`, `"windows"`, or `"default"`. |
+| `code-window-enabled`           | boolean | `true`  | Set to `false` to disable window chrome while keeping annotations.     |
+| `code-window-no-auto-filename`  | boolean | `false` | Suppress the auto-generated filename for this block.                   |
 
 ````markdown
 ```{.python filename="example.py" code-window-style="windows"}

--- a/README.md
+++ b/README.md
@@ -112,28 +112,17 @@ After that, the extension will focus solely on **auto-filename** and **code-wind
 - **`hotfix.skylighting`**: overrides Pandoc's Skylighting output for Typst to fix block and inline code styling.
 - **`hotfix.typst-title`**: evaluates theorem title strings as Typst markup so that inline formatting (e.g., code) renders correctly.
 
-Each hotfix can specify its own `quarto-version` threshold, since upstream fixes may land in different Quarto releases:
+Each hotfix accepts either a boolean or a map with `enabled` and `quarto-version` keys for per-hotfix version thresholds (upstream fixes may land in different Quarto releases):
 
 ```yaml
 extensions:
   code-window:
     hotfix:
-      code-annotations:
-        quarto-version: "1.10.0"
-      skylighting:
-        quarto-version: "1.11.0"
-      typst-title:
-        quarto-version: "1.10.0"
-```
-
-The map form also accepts an `enabled` key to explicitly enable or disable a hotfix regardless of version:
-
-```yaml
-extensions:
-  code-window:
-    hotfix:
+      code-annotations: true
       skylighting:
         enabled: false
+      typst-title:
+        quarto-version: "1.10.0"
 ```
 
 Future removal playbook:

--- a/_extensions/code-window/_schema.yml
+++ b/_extensions/code-window/_schema.yml
@@ -62,6 +62,10 @@ attributes:
       type: boolean
       default: true
       description: "Whether to apply window chrome to this specific code block. Set to false to disable. Annotations still render when disabled."
+    code-window-no-auto-filename:
+      type: boolean
+      default: false
+      description: "Suppress the auto-generated filename for this specific code block without changing the global setting."
     code-window-style:
       type: string
       enum: ["default", "macos", "windows"]

--- a/example.qmd
+++ b/example.qmd
@@ -93,7 +93,17 @@ No window decoration is applied here.
 
 ## Disabled Auto-Filename
 
-To disable auto-generated filenames, set `auto-filename: false` in the extension configuration.
+### Per Block
+
+Set `code-window-no-auto-filename="true"` on a single block to suppress the auto-generated filename without changing the global setting.
+
+```{.python code-window-no-auto-filename="true"}
+print("No auto-filename on this block")
+```
+
+### Globally
+
+To disable auto-generated filenames for the entire document, set `auto-filename: false` in the extension configuration.
 Only code blocks with an explicit `filename` attribute will display window decorations.
 
 ```yaml
@@ -212,11 +222,27 @@ Set the global style in the document front matter:
 ```yaml
 extensions:
   code-window:
+    enabled: true
+    auto-filename: true
     style: "macos"
+    wrapper: "code-window"
     hotfix:
-      quarto-version: ~
       code-annotations: true
       skylighting: true
+      typst-title: true
+```
+
+Each hotfix accepts either a boolean or a map with `enabled` and `quarto-version` keys for per-hotfix version thresholds:
+
+```yaml
+extensions:
+  code-window:
+    hotfix:
+      code-annotations: true
+      skylighting:
+        enabled: false
+      typst-title:
+        quarto-version: "1.10.0"
 ```
 
 Override per block with the `code-window-style` attribute:


### PR DESCRIPTION
Add missing features to example.qmd: per-block `code-window-no-auto-filename` attribute, all global options (`enabled`, `auto-filename`, `wrapper`), `typst-title` hotfix, and the map form for per-hotfix version thresholds.

Replace the README "Block-Level Style Override" section with a "Block-Level Attributes" table covering `code-window-style`, `code-window-enabled`, and `code-window-no-auto-filename`. Consolidate the hotfix YAML examples into a single block showing both the boolean and map forms side by side.

Add the `code-window-no-auto-filename` attribute to `_schema.yml` to match the existing Lua implementation.