### PR TITLE
feat: derive Typst window chrome colours from page background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: derive Typst window chrome colours from page background for dark theme support.
+
 ## 0.4.0 (2026-03-29)
 
 ### Bug Fixes

--- a/_extensions/code-window/_modules/hotfix/skylighting-typst-fix.lua
+++ b/_extensions/code-window/_modules/hotfix/skylighting-typst-fix.lua
@@ -43,6 +43,9 @@ local function build_skylighting_override()
   let has-gutter = start + sourcelines.len() > 999
 
   context {
+    let _page-bg = _cw-page-bg()
+    let _fg = _cw-fg(_page-bg)
+    let _border-colour = color.mix((_fg, 15%%), (_page-bg, 85%%))
     let annot-data = _cw-annotations.get()
     let blocks = []
     let lnum = start - 1
@@ -94,7 +97,7 @@ local function build_skylighting_override()
       width: 100%%,
       inset: 8pt,
       radius: 2pt,
-      stroke: 0.5pt + luma(200),
+      stroke: 0.5pt + _border-colour,
       blocks,
     )
   }
@@ -159,7 +162,7 @@ end
 --- @return pandoc.RawInline|pandoc.Code Transformed or original element
 local function process_typst_inline(el)
   local hm = PANDOC_WRITER_OPTIONS and PANDOC_WRITER_OPTIONS.highlight_method
-  local bg_fill = 'luma(230)'
+  local bg_fill = nil
   local write_opts = nil
 
   if hm then
@@ -176,11 +179,18 @@ local function process_typst_inline(el)
   rendered = rendered:gsub('%s+$', '')
   if rendered == '' then return el end
 
-  local typst_code = string.format(
-    '#box(fill: %s, inset: (x: 3pt, y: 0pt), outset: (y: 3pt), radius: 2pt, stroke: none)[%s]',
-    bg_fill,
-    rendered
-  )
+  local typst_code
+  if bg_fill then
+    typst_code = string.format(
+      '#box(fill: %s, inset: (x: 3pt, y: 0pt), outset: (y: 3pt), radius: 2pt, stroke: none)[%s]',
+      bg_fill, rendered)
+  else
+    typst_code = string.format(
+      '#context { let _bg = _cw-page-bg(); let _f = _cw-fg(_bg); '
+      .. 'box(fill: color.mix((_f, 10%%), (_bg, 90%%)), '
+      .. 'inset: (x: 3pt, y: 0pt), outset: (y: 3pt), radius: 2pt, stroke: none)[%s] }',
+      rendered)
+  end
 
   return pandoc.RawInline('typst', typst_code)
 end

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -78,6 +78,27 @@ end
 -- TYPST FUNCTION DEFINITION
 -- ============================================================================
 
+--- Typst colour helpers for adaptive theme support.
+--- Always injected so the code-window function can derive border, surface,
+--- and muted colours from the page background at render time.
+local TYPST_COLOUR_HELPERS = [==[
+// code-window: adaptive colour helpers (derive UI tones from page background)
+#let _cw-page-bg() = {
+  let f = page.fill
+  if type(f) == color { f } else { luma(255) }
+}
+
+#let _cw-fg(bg) = {
+  let comps = bg.components(alpha: false)
+  let lum = if comps.len() == 1 {
+    comps.at(0) / 100%
+  } else {
+    0.2126 * comps.at(0) / 100% + 0.7152 * comps.at(1) / 100% + 0.0722 * comps.at(2) / 100%
+  }
+  if lum < 0.5 { luma(255) } else { luma(0) }
+}
+]==]
+
 --- Typst annotation helper functions (state, colour, circled numbers, annotation items).
 --- Only injected when at least one hot-fix is active.
 local TYPST_ANNOTATION_DEF = [==[
@@ -157,8 +178,8 @@ local TYPST_CONTENT_PLAIN = [==[
 --- @return string Typst function definition(s)
 local function build_typst_function_def(has_hotfixes)
   local content_block = has_hotfixes
-    and TYPST_CONTENT_WITH_ANNOTATIONS
-    or TYPST_CONTENT_PLAIN
+      and TYPST_CONTENT_WITH_ANNOTATIONS
+      or TYPST_CONTENT_PLAIN
 
   local fn_def = string.format([==[
 #let code-window(
@@ -170,9 +191,12 @@ local function build_typst_function_def(has_hotfixes)
   bg-colour: none,
   block-id: 0,
 ) = {
-  let border-colour = luma(200)
-  let surface-fill = luma(237)
-  let muted-colour = luma(120)
+  context {
+  let page-bg = _cw-page-bg()
+  let fg = _cw-fg(page-bg)
+  let border-colour = color.mix((fg, 15%%), (page-bg, 85%%))
+  let surface-fill = color.mix((fg, 5%%), (page-bg, 95%%))
+  let muted-colour = color.mix((fg, 50%%), (page-bg, 50%%))
 
   let filename-label = if filename != none {
     text(
@@ -276,13 +300,15 @@ local function build_typst_function_def(has_hotfixes)
 %s      }
     },
   )
+  }
 }
 ]==], content_block)
 
+  local result = TYPST_COLOUR_HELPERS
   if has_hotfixes then
-    return TYPST_ANNOTATION_DEF .. fn_def
+    result = result .. TYPST_ANNOTATION_DEF
   end
-  return fn_def
+  return result .. fn_def
 end
 
 -- ============================================================================


### PR DESCRIPTION
Replaces hardcoded light-theme luma() values in the Typst code-window function with adaptive colour computation derived from the document's page.fill at render time. Two small Typst helper functions (_cw-page-bg and _cw-fg) resolve the page background and its contrast foreground, then color.mix() derives border, surface, and muted colours at CSS-matching ratios (15%, 5%, 50%).

The same adaptive approach is applied to the Skylighting override stroke and the inline code background fallback. Traffic light colours remain fixed.

On a default white page the output is visually close to the previous hardcoded values. On dark or coloured page backgrounds the chrome now adapts correctly instead of rendering light-theme greys.