### PR TITLE
style: reduce Reveal.js title bar height by 35%

### DIFF
--- a/_extensions/code-window/style.css
+++ b/_extensions/code-window/style.css
@@ -32,8 +32,9 @@
   break-after: avoid;
 }
 
-/* Restore title bar padding for Reveal.js slides */
+/* Shrink title bar ~35% on Reveal.js slides (scales padding, decorations, and filename text proportionally) */
 .reveal .code-with-filename .code-with-filename-file {
+  font-size: 0.65em;
   padding: 0.3em 1em;
 }
 


### PR DESCRIPTION
Reduces the code-window title bar height on Reveal.js slides by 35% by setting \`font-size: 0.65em\` on the Reveal.js-scoped title bar rule. Because all title-bar dimensions (padding, gap, decoration sizes, filename font-size) are expressed in \`em\`, they scale proportionally without touching the HTML or Typst outputs.