### PR TITLE
fix: preserve code-annotation structure for HTML/Reveal.js auto-filename blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: preserve code-annotation structure for HTML/Reveal.js auto-filename blocks.
+
 ## 1.0.1 (2026-04-10)
 
 ### Bug Fixes

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -414,38 +414,55 @@ local function process_html(block)
   end
 
   local filename = block.classes[1]
-  local effective_style = block_style or CONFIG.style
 
-  local filename_header = pandoc.RawBlock(
-    'html',
-    string.format(
-      '<div class="code-with-filename-file"><pre><strong>%s</strong></pre></div>',
-      str.escape_html(filename)
-    )
-  )
+  -- Set the filename attribute so Quarto creates its own .code-with-filename
+  -- wrapper. This preserves the CodeBlock+OrderedList sibling structure
+  -- needed by Quarto's code-annotations processor.
+  block.attributes['filename'] = filename
+  table.insert(block.classes, 'cw-auto')
+  if block_style then
+    table.insert(block.classes, 'cw-style-' .. block_style)
+  end
 
-  return pandoc.Div(
-    { filename_header, block },
-    pandoc.Attr('', { 'code-with-filename', 'code-window-' .. effective_style, 'code-window-auto' })
-  )
+  return block
 end
 
 -- ============================================================================
 -- FILTER HANDLERS
 -- ============================================================================
 
---- Generate a JS snippet that adds the configured default style class
---- to Quarto-created .code-with-filename wrappers (explicit filenames)
+--- Generate a JS snippet that builds .code-with-filename wrappers for
+--- auto-filename blocks (marked with cw-auto at pre-quarto), applies the
+--- configured default style class to all .code-with-filename wrappers,
 --- and promotes block-level cw-style-* marker classes.
 --- @param default_style string The configured default style
 --- @return string JavaScript code
 local function make_style_js(default_style)
   return string.format([=[
 document.addEventListener("DOMContentLoaded",function(){
+  document.querySelectorAll("pre.cw-auto").forEach(function(pre){
+    var fn=pre.closest("[data-filename]");
+    if(!fn)return;
+    var name=fn.getAttribute("data-filename");
+    if(!name)return;
+    var scaffold=pre.closest(".code-copy-outer-scaffold")||pre.closest(".sourceCode");
+    if(!scaffold)return;
+    var w=document.createElement("div");
+    w.className="code-with-filename code-window-auto";
+    var tb=document.createElement("div");
+    tb.className="code-with-filename-file";
+    var tp=document.createElement("pre");
+    var ts=document.createElement("strong");
+    ts.textContent=name;
+    tp.appendChild(ts);tb.appendChild(tp);
+    scaffold.parentNode.insertBefore(w,scaffold);
+    w.appendChild(tb);w.appendChild(scaffold);
+    pre.classList.remove("cw-auto");
+  });
   document.querySelectorAll(".code-with-filename").forEach(function(el){
     if(/\bcode-window-(macos|windows|default)\b/.test(el.className))return;
     var c=el.querySelector('[class*="cw-style-"]');
-    if(c){var m=c.className.match(/cw-style-(\w+)/);if(m){el.classList.add("code-window-"+m[1]);return;}}
+    if(c){var m=c.className.match(/cw-style-(\w+)/);if(m){el.classList.add("code-window-"+m[1]);c.classList.remove(m[0]);return;}}
     el.classList.add("code-window-%s");
   });
 });]=], default_style)


### PR DESCRIPTION
The pre-quarto filter wrapped auto-filename CodeBlocks in a custom Div, breaking the sibling relationship between the CodeBlock and its following OrderedList that Quarto's annotation processor requires. Annotations rendered as a plain `<ol>` instead of an interactive `<dl>` with `data-target-cell` attributes.

The Lua-side Div wrapping is replaced with a `filename` attribute and `cw-auto` marker class on the CodeBlock. The injected DOMContentLoaded JS now builds the `.code-with-filename` wrapper at render time, after Quarto has finished processing annotations. This preserves the annotation structure while maintaining the visual code-window chrome for both HTML and Reveal.js formats.