### PR TITLE
fix: apply Typst code-window styling inside container blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: apply Typst code-window styling to code blocks inside lists, blockquotes, and definition lists.
+
 ## 1.1.0 (2026-04-12)
 
 ### Bug Fixes

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -799,6 +799,27 @@ local function process_typst_blocks(blocks)
         pending_annot_block_id = nil
         i = i + 1
       end
+    elseif blk.t == 'BulletList' or blk.t == 'OrderedList' then
+      for j, item in ipairs(blk.content) do
+        blk.content[j] = process_typst_blocks(pandoc.Blocks(item))
+      end
+      table.insert(new_blocks, blk)
+      pending_annot_block_id = nil
+      i = i + 1
+    elseif blk.t == 'BlockQuote' then
+      blk.content = process_typst_blocks(blk.content)
+      table.insert(new_blocks, blk)
+      pending_annot_block_id = nil
+      i = i + 1
+    elseif blk.t == 'DefinitionList' then
+      for j, def_item in ipairs(blk.content) do
+        for k, body in ipairs(def_item[2]) do
+          def_item[2][k] = process_typst_blocks(pandoc.Blocks(body))
+        end
+      end
+      table.insert(new_blocks, blk)
+      pending_annot_block_id = nil
+      i = i + 1
     else
       pending_annot_block_id = nil
       table.insert(new_blocks, blk)


### PR DESCRIPTION
The Typst block processor in \`process_typst_blocks()\` only recursed into Div elements when walking the document tree. Code blocks nested inside BulletList, OrderedList, BlockQuote, or DefinitionList were passed through without code-window styling.

This adds recursion into those container block types so that nested code blocks receive the same Typst window chrome as top-level ones.