### PR TITLE
fix: use CSS Canvas system colour for code-window background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: use CSS `Canvas` system colour so code-window chrome and body render against the page background, not a parent container's background.
+
 ## 1.1.1 (2026-04-13)
 
 ### Bug Fixes

--- a/_extensions/code-window/style.css
+++ b/_extensions/code-window/style.css
@@ -10,7 +10,8 @@
 .code-with-filename {
   margin: 1.5em 0;
   border-radius: 8px;
-  border: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 15%, Canvas);
+  background-color: Canvas;
   overflow: hidden;
   page-break-inside: avoid;
   break-inside: avoid;
@@ -21,9 +22,9 @@
   display: flex;
   align-items: center;
   gap: 0.75em;
-  background-color: color-mix(in srgb, currentColor 5%, transparent);
+  background-color: color-mix(in srgb, currentColor 5%, Canvas);
   border: none;
-  border-bottom: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, currentColor 15%, Canvas);
   border-radius: 0;
   padding: 0.2em 1em;
   line-height: 1.2;
@@ -47,7 +48,7 @@
   border: none;
   font-size: 0.85em;
   font-weight: 500;
-  color: color-mix(in srgb, currentColor 50%, transparent);
+  color: color-mix(in srgb, currentColor 50%, Canvas);
 }
 
 /* Code block content area */


### PR DESCRIPTION
Replace `transparent` with the CSS system colour `Canvas` in all `color-mix` rules and add `background-color: Canvas` on the `.code-with-filename` container. `Canvas` resolves to the page background colour, so code-window chrome and body no longer inherit a parent container's background. This aligns HTML/Reveal.js output with the Typst path, which already derives colours from `page.fill`.