### PR TITLE
fix: wrap code-window blocks in layout divs to preserve column count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: wrap code-window blocks in a plain Div when they are direct children of a Quarto layout div (`layout-ncol`, `layout-nrow`, `layout`), so that Quarto's grid assigns one column per code block instead of one column per raw block.
+
 ## 1.1.3 (2026-04-15)
 
 ### Refactoring

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -730,7 +730,7 @@ end
 --- @param blocks pandoc.Blocks|pandoc.List
 --- @return pandoc.Blocks processed_blocks
 --- @return integer|nil pending_annotation_block_id Block ID if the last block had annotations (for parent consumption)
-local function process_typst_blocks(blocks)
+local function process_typst_blocks(blocks, wrap_codeblocks)
   local new_blocks = {}
   local pending_annot_block_id = nil
   local i = 1
@@ -740,7 +740,9 @@ local function process_typst_blocks(blocks)
     if blk.t == 'CodeBlock' then
       local next_blk = blocks[i + 1]
       local replacement, consumed_next, annot_id = process_typst_block(blk, next_blk)
-      for _, rb in ipairs(replacement) do
+      local to_insert = (wrap_codeblocks and #replacement > 1)
+        and pandoc.Blocks({ pandoc.Div(pandoc.Blocks(replacement)) }) or replacement
+      for _, rb in ipairs(to_insert) do
         table.insert(new_blocks, rb)
       end
       if consumed_next then
@@ -757,7 +759,9 @@ local function process_typst_blocks(blocks)
       if inner_block then
         local next_blk = blocks[i + 1]
         local replacement, consumed_next, annot_id = process_typst_block(inner_block, next_blk)
-        for _, rb in ipairs(replacement) do
+        local to_insert = (wrap_codeblocks and #replacement > 1)
+          and pandoc.Blocks({ pandoc.Div(pandoc.Blocks(replacement)) }) or replacement
+        for _, rb in ipairs(to_insert) do
           table.insert(new_blocks, rb)
         end
         if consumed_next then
@@ -776,7 +780,10 @@ local function process_typst_blocks(blocks)
         i = i + 1
       end
     elseif blk.t == 'Div' then
-      local processed, inner_pending = process_typst_blocks(blk.content)
+      local is_layout = blk.attributes['layout-ncol']
+        or blk.attributes['layout-nrow']
+        or blk.attributes['layout']
+      local processed, inner_pending = process_typst_blocks(blk.content, is_layout)
       blk.content = processed
       table.insert(new_blocks, blk)
       -- If the Div's last processed block had pending annotations,

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -741,7 +741,7 @@ local function process_typst_blocks(blocks, wrap_codeblocks)
       local next_blk = blocks[i + 1]
       local replacement, consumed_next, annot_id = process_typst_block(blk, next_blk)
       local to_insert = (wrap_codeblocks and #replacement > 1)
-        and pandoc.Blocks({ pandoc.Div(pandoc.Blocks(replacement)) }) or replacement
+        and { pandoc.Div(replacement) } or replacement
       for _, rb in ipairs(to_insert) do
         table.insert(new_blocks, rb)
       end
@@ -760,7 +760,7 @@ local function process_typst_blocks(blocks, wrap_codeblocks)
         local next_blk = blocks[i + 1]
         local replacement, consumed_next, annot_id = process_typst_block(inner_block, next_blk)
         local to_insert = (wrap_codeblocks and #replacement > 1)
-          and pandoc.Blocks({ pandoc.Div(pandoc.Blocks(replacement)) }) or replacement
+          and { pandoc.Div(replacement) } or replacement
         for _, rb in ipairs(to_insert) do
           table.insert(new_blocks, rb)
         end


### PR DESCRIPTION
Code blocks placed as direct children of a Quarto layout div (`layout-ncol`, `layout-nrow`, `layout`) were rendered incorrectly in Typst output. The code-window filter replaced each single `CodeBlock` with three blocks (a Typst open `RawBlock`, the `CodeBlock`, and a Typst close `RawBlock`), so a layout div with N code blocks ended up with 3N direct children. Quarto's grid processor counted those 3N children and distributed them across columns instead of N, producing the wrong layout.

The fix passes a `wrap_codeblocks` flag when recursing into layout divs. When set, each multi-block replacement is wrapped in a plain `pandoc.Div`, restoring the 1-to-1 child count and letting Quarto assign exactly one grid cell per code block.