### PR TITLE
fix(typst): remove sticky from title-bar block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix(typst): remove `sticky: true` from the title-bar block so page-sized code windows start on the current page instead of being postponed, leaving near-empty pages behind (orphaned heading, then an empty window frame). The title bar may now occasionally sit alone at the bottom of a page; the code body still breaks across pages correctly.
+
 ## 1.2.0 (2026-05-31)
 
 ### New Features

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -358,7 +358,6 @@ local function build_typst_function_def(has_hotfixes)
         below: 0pt,
         radius: 0pt,
         stroke: (bottom: 1pt + border-colour),
-        sticky: true,
         title-bar,
       )
       // Strip code block chrome so content fills flush against the window body.


### PR DESCRIPTION
In Typst output, the title-bar block carried `sticky: true`, which requires the code body to start on the same page as the title bar. When the body approaches a full page, the Typst versions bundled with stable Quarto (0.13 and earlier) postpone the whole window to the next page instead of fragmenting the body. This cascades into near-empty pages: an orphaned section heading, then a title bar alone in an empty window frame, with the code starting only on the following page. On a real document embedding eight 60-110 line files, this produced 26 near-empty pages out of 70.

This removes the `sticky` property (Typst's default is `sticky: false`), so the window starts on the current page and the body breaks across pages as before. The title bar may now occasionally sit alone at the bottom of a page with the code starting on the next one, which is minor compared to pairs of near-empty pages. Typst 0.14 fragments correctly with or without `sticky`, so the change is neutral there.

Bisected on the affected document: `clip: false` and explicit `breakable: true` change nothing; removing `sticky` alone drops near-empty pages from 26 to 2.