### PR TITLE
feat: frame no-language and unknown-language code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: code blocks with no language or an unknown language are now framed like highlighted code cells instead of being left as bare blocks. A no-language block is labelled `default`; an unknown language keeps its original token as the label. Override per block with an explicit `filename`, `code-window-no-auto-filename="true"`, or `code-window-enabled="false"`, or globally with `auto-filename: false`.
+
 ## 1.2.1 (2026-07-10)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ extensions:
 | Option          | Type           | Default         | Description                                                                                              |
 | --------------- | -------------- | --------------- | -------------------------------------------------------------------------------------------------------- |
 | `enabled`       | boolean        | `true`          | Enable or disable the code-window filter.                                                                |
-| `auto-filename` | boolean        | `true`          | Automatically generate filename labels from the code block language. Set to `false` to disable globally. |
+| `auto-filename` | boolean        | `true`          | Automatically generate filename labels from the code block language, and frame no-language / unknown-language blocks like highlighted cells (a no-language block is labelled `default`; an unknown language keeps its original token). Set to `false` to disable globally. |
 | `style`         | string         | `"macos"`       | Window decoration style: `"macos"`, `"windows"`, or `"default"`.                                         |
 | `wrapper`       | string         | `"code-window"` | Typst wrapper function name for code-window rendering.                                                   |
 | `collapse`      | boolean/string | `false`         | Wrap every code window in a `<details>` element (HTML). Accepts `false`, `true`, `"open"`, `"closed"`.   |

--- a/_extensions/code-window/_modules/language.lua
+++ b/_extensions/code-window/_modules/language.lua
@@ -29,14 +29,19 @@ local function is_known_language(lang)
 end
 
 --- Normalise code blocks with no or unknown language class to "default".
---- For unknown languages, preserves the original name as an explicit
---- filename when one is not already set.
+--- Both are framed like a highlighted code cell rather than left as a bare
+--- block: a no-language block is labelled "default", and an unknown language
+--- keeps its original token as the label. The label is carried on the
+--- `code-window-auto-label` attribute (not `filename`, which is reserved for
+--- author-set filenames) and consumed by the auto-filename windowing path.
 --- @param block pandoc.CodeBlock
 --- @return pandoc.CodeBlock
 function M.CodeBlock(block)
   if not block.classes or #block.classes == 0 then
     block.classes:insert('default')
-    block.attributes['code-window-no-auto-filename'] = 'true'
+    if not block.attributes['filename'] or block.attributes['filename'] == '' then
+      block.attributes['code-window-auto-label'] = 'default'
+    end
     return block
   end
 
@@ -44,7 +49,7 @@ function M.CodeBlock(block)
   if not is_known_language(lang) then
     block.classes[1] = 'default'
     if not block.attributes['filename'] or block.attributes['filename'] == '' then
-      block.attributes['filename'] = lang
+      block.attributes['code-window-auto-label'] = lang
     end
   end
 

--- a/_extensions/code-window/code-window.lua
+++ b/_extensions/code-window/code-window.lua
@@ -520,7 +520,11 @@ local function process_html(block)
     return block
   end
 
-  local filename = block.classes[1]
+  -- Default/unknown/no-language blocks carry their label on
+  -- code-window-auto-label (set by the language module); everything else uses
+  -- its language class.
+  local filename = block.attributes['code-window-auto-label'] or block.classes[1]
+  block.attributes['code-window-auto-label'] = nil
 
   -- Set the filename attribute so Quarto creates its own .code-with-filename
   -- wrapper. This preserves the CodeBlock+OrderedList sibling structure
@@ -786,7 +790,10 @@ local function resolve_window_params(block)
 
   if (not filename or filename == '') and not no_auto then
     if CONFIG.auto_filename and block.classes and #block.classes > 0 then
-      filename = block.classes[1]
+      -- Default/unknown/no-language blocks carry their label on
+      -- code-window-auto-label; everything else uses its language class.
+      filename = block.attributes['code-window-auto-label'] or block.classes[1]
+      block.attributes['code-window-auto-label'] = nil
       is_auto = true
     end
   end


### PR DESCRIPTION
Code blocks with no language or an unknown language are now framed like highlighted code cells instead of being left as bare blocks. A no-language block is labelled `default`; an unknown language keeps its original token as the label.

The label is carried on a new `code-window-auto-label` attribute rather than overloading `filename`, which stays reserved for author-set filenames. Both the HTML and Typst auto-filename paths read and clear it. Authors can override per block with an explicit `filename`, `code-window-no-auto-filename="true"`, or `code-window-enabled="false"`, or globally with `auto-filename: false`.