### PR TITLE
docs: document filters with the bare extension name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Documentation
+
+- docs: Document the filter as `filters:` with the bare `code-window` name. The long form `path`/`at` overrides the entry point of every filter the extension contributes, so the documented `at: pre-quarto` pulled the Typst title hotfix from `post-quarto` to `pre-quarto`; the manifest already carries both entry points.
+
 ## 1.3.1 (2026-08-01)
 
 ### Bug Fixes

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -17,8 +17,7 @@ Every named code block on this site is drawn by it, including this one:
 
 ```{.yaml filename="_quarto.yml"}
 filters:
-  - path: code-window
-    at: pre-quarto
+  - code-window
 ```
 
 ## Installation
@@ -44,8 +43,7 @@ Or install it from your editor with [Quarto Wizard](https://m.canouil.dev/quarto
 
 ```yaml
 filters:
-  - path: code-window
-    at: pre-quarto
+  - code-window
 ```
 
 Name the file, and the block is framed with it:

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -8,8 +8,7 @@ description: "The complete code-window configuration: the document options, the 
 
 ```yaml
 filters:
-  - path: code-window
-    at: pre-quarto
+  - code-window
 ```
 
 ## Options

--- a/example.qmd
+++ b/example.qmd
@@ -6,8 +6,7 @@ author:
     orcid: "0000-0002-3396-4549"
     url: "https://mickael.canouil.fr"
 filters:
-  - at: pre-quarto
-    path: code-window
+  - code-window
 syntax-highlighting: github-dark
 code-annotations: below
 toc: true


### PR DESCRIPTION
The documented long `path`/`at` form overrides the entry point of every filter an extension contributes, so `at: pre-quarto` also moved `typst-title-fix.lua` off `post-quarto`. The manifest already carries both entry points, so the documentation and `example.qmd` now name the extension alone.