### PR TITLE
build: update the vendored Lua modules to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - docs: Serve the extension's social card as the Open Graph image, so a shared link shows the card rather than the first image on the page. (#58)
 
+### Refactoring
+
+- build: Update the vendored Lua modules to 2.3.0. A module no longer carries a version line in its header, so its checksum changes only when its code changes. (#59)
+
 ## 1.5.0 (2026-09-06)
 
 ### New Features

--- a/_extensions/code-window/_dependencies.yml
+++ b/_extensions/code-window/_dependencies.yml
@@ -3,26 +3,26 @@ sources:
   quarto-lua-modules:
     origin: "https://github.com/mcanouil/quarto-lua-modules"
     fetch: "{origin}/releases/download/{version}/{file}"
-    version: "2.2.0"
+    version: "2.3.0"
     licence: MIT
     files:
       html.lua:
-        sha256: "d5b01fe9e02923746edc905734bb99387083b9e419a0f7effdd4a3fb95a792d3"
+        sha256: "a7aae5e69c4effce399b85e90f3ee3261d0f84a5ac2f6c7ddeb1e358ba22ddc8"
         runtime: any
       logging.lua:
-        sha256: "1a8339db434d4cc8f794a2e2526ffe002124b3f71df3e3ef47eb9db3a3b24296"
+        sha256: "5d99ceb89c813fbe4491310e42b4a4cff62e11dda42f01b4f61f969aa58e0706"
         runtime: any
       metadata.lua:
-        sha256: "83fc3757c1ca7d7d63fcf5bf6a8d4ac60144adfc95af2a90559d52d203e153fb"
+        sha256: "1186431acc50e35797eef68808e4c52321c845a3be4f29bbd7de695b1db2f6cc"
         runtime: any
       pandoc-helpers.lua:
-        sha256: "b0ea450d91bbe1e74fe6848fdd74d896e8242f08d18731065778bb89b30e51f3"
+        sha256: "519cdfa87e0026cfaf754639c8f07faefa4e0d21819f463f8b202448fe0f4d7e"
         runtime: any
       schema-check.lua:
-        sha256: "05277cebd3f1164544897e3fbe563404b88115364ed9a93e1d464f246b157b25"
+        sha256: "7c4dc34f31b85ff7bc4e2511f73e2301377e964e57ea5374ad97e7817a10af4b"
         runtime: any
       string.lua:
-        sha256: "f14a487f61d027e38c9cb32f280bd5266e73ef76e31bd61fdff184c2e588698d"
+        sha256: "7801d2f217e803951313ef86f1f899cb6350a44cbb468b2d7c28dd6911a0fadc"
         runtime: any
   quarto-wizard:
     origin: "https://github.com/mcanouil/quarto-wizard"

--- a/_extensions/code-window/_vendor/quarto-lua-modules/html.lua
+++ b/_extensions/code-window/_vendor/quarto-lua-modules/html.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.2.0
 
 local M = {}
 

--- a/_extensions/code-window/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/code-window/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.2.0
 
 local M = {}
 

--- a/_extensions/code-window/_vendor/quarto-lua-modules/metadata.lua
+++ b/_extensions/code-window/_vendor/quarto-lua-modules/metadata.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.2.0
 
 local M = {}
 

--- a/_extensions/code-window/_vendor/quarto-lua-modules/pandoc-helpers.lua
+++ b/_extensions/code-window/_vendor/quarto-lua-modules/pandoc-helpers.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.2.0
 
 local M = {}
 

--- a/_extensions/code-window/_vendor/quarto-lua-modules/schema-check.lua
+++ b/_extensions/code-window/_vendor/quarto-lua-modules/schema-check.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.2.0
 ---
 --- Holds the wiring that every extension would otherwise copy: read the schema
 --- once, check the document configuration against it, check one shortcode call

--- a/_extensions/code-window/_vendor/quarto-lua-modules/string.lua
+++ b/_extensions/code-window/_vendor/quarto-lua-modules/string.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.2.0
 
 local M = {}
 


### PR DESCRIPTION
Updates the vendored Lua modules from 2.2.0 to 2.3.0 and repins each checksum.

The 2.3.0 release drops the `--- @version` line that every module carried. The release used to stamp that line at each version, so a module's bytes changed on every release even when its code did not, and a vendored copy could never match a later release by checksum. The manifest already records the version this extension took.

Verified with `vendor.sh --check`, which reports every declared source at the version its origin publishes.